### PR TITLE
Update broken link for Pragmatic Programmers Guide to Ruby

### DIFF
--- a/docs/tutorials/everyday_ronin.md
+++ b/docs/tutorials/everyday_ronin.md
@@ -34,7 +34,7 @@ $ ronin irb
 <div class="note">
   <p>
   <b>Note:</b> If you are new to the Ruby programming language, you might
-  consider reviewing the <a href="http://www.rubycentral.com/book/">Pragmatic Programmers Guide to Ruby</a>,
+  consider reviewing the <a href="https://ruby-doc.com/docs/ProgrammingRuby/">Pragmatic Programmers Guide to Ruby</a>,
   since it is expected that users of the Ronin Ruby Console have a basic
   understanding of Ruby programming practices.
   </p>


### PR DESCRIPTION
I have updated the broken link for the "Pragmatic Programmers Guide to Ruby" in the README/documentation. The previous link (http://www.rubycentral.com/book/) was no longer accessible, so I replaced it with the working link (https://ruby-doc.com/docs/ProgrammingRuby/). This change will help users quickly find the right resource for learning Ruby.
