### PR TITLE
Fix an unclear instruction which won't work

### DIFF
--- a/install/nix/index.md
+++ b/install/nix/index.md
@@ -8,7 +8,7 @@ title: Install - Nix
 ## Copy/Paste Instructions
 
 ```shell
-nix-env -iA ronin
+nix-env -iA nixpkgs.ronin
 ```
 
 ## Detailed Breakdown


### PR DESCRIPTION
`nix-env -iA ronin` won't work. It should be `nix-env -iA nixpkgs.ronin` or `nix-env -iA nixos.ronin`.

See #23 