### PR TITLE
Fixed the broken Guides link in the Ronin CLI guide

### DIFF
--- a/docs/guides/using-the-ronin-cli/index.md
+++ b/docs/guides/using-the-ronin-cli/index.md
@@ -220,7 +220,7 @@ sub-commands with their own man-pages.
   </div>
 
   <div class="level-item">
-    <a class="button" href="../index.html#guides">
+    <a class="button" href="/docs/#guides">
       &#x2303; Guides
     </a>
   </div>


### PR DESCRIPTION
Related to #48 

Repairing Guides link for the "Using Ronin CLI" page.