### PR TITLE
Fixed the broken Guides link in the Ronin Ruby Shell guide

### DIFF
--- a/docs/guides/using-the-ronin-ruby-shell/index.md
+++ b/docs/guides/using-the-ronin-ruby-shell/index.md
@@ -142,14 +142,14 @@ To view a full list of the available Mixin methods, see the documentation for
   </div>
 
   <div class="level-item">
-    <a class="button" href="../index.html#guides">
+    <a class="button" href="/docs/#guides">
       &#x2303; Guides
     </a>
   </div>
 
   <div class="level-right">
-    <a class="button" href="../writting-ronin-ruby-scripts/">
-      Writing Ronin Ruby Scripts &raquo;
+    <a class="button" href="../using-ronin-repos/">
+      Using Ronin Repos &raquo;
     </a>
   </div>
 </div>

--- a/docs/guides/using-the-ronin-ruby-shell/index.md
+++ b/docs/guides/using-the-ronin-ruby-shell/index.md
@@ -147,9 +147,9 @@ To view a full list of the available Mixin methods, see the documentation for
     </a>
   </div>
 
-  <div class="level-right">
-    <a class="button" href="../using-ronin-repos/">
-      Using Ronin Repos &raquo;
+ <div class="level-right">
+    <a class="button" href="../writing-ronin-ruby-scripts/">
+      Writing Ronin Ruby Scripts &raquo;
     </a>
   </div>
 </div>

--- a/docs/guides/using-the-ronin-ruby-shell/index.md
+++ b/docs/guides/using-the-ronin-ruby-shell/index.md
@@ -147,9 +147,9 @@ To view a full list of the available Mixin methods, see the documentation for
     </a>
   </div>
 
- <div class="level-right">
-    <a class="button" href="../writing-ronin-ruby-scripts/">
-      Writing Ronin Ruby Scripts &raquo;
+  <div class="level-right">
+    <a class="button" href="../ruby-quick-ref/">
+      Ruby Quick Ref &raquo;
     </a>
   </div>
 </div>


### PR DESCRIPTION
Related #48 

Repairing Guides link for the "Using Ronin Ruby Shell" page