### PR TITLE
Fixed the broken Guides link in the Ronin DB guide

### DIFF
--- a/docs/guides/using-ronin-db/index.md
+++ b/docs/guides/using-ronin-db/index.md
@@ -158,8 +158,8 @@ there are pending migrations. You will have to run `ronin-db migrate`.
 
 <div class="level">
   <div class="level-left">
-    <a class="button" href="../using-ronin-repos/">
-      &laquo; Using Ronin Repos
+    <a class="button" href="../using-the-ronin-cli/">
+      Using the Ronin CLI &raquo;
     </a>
   </div>
 
@@ -168,13 +168,8 @@ there are pending migrations. You will have to run `ronin-db migrate`.
       &#x2303; Guides
     </a>
   </div>
-
-  <div class="level-right">
-    <a class="button" href="../ruby-quick-ref/">
-      Ruby Quick Ref &raquo;
-    </a>
-  </div>
 </div>
+
 
 [ronin-db]: https://github.com/ronin-rb/ronin-db#readme
 [ronin-db-synopsis]: https://github.com/ronin-rb/ronin-db#synopsis

--- a/docs/guides/using-ronin-db/index.md
+++ b/docs/guides/using-ronin-db/index.md
@@ -170,7 +170,6 @@ there are pending migrations. You will have to run `ronin-db migrate`.
   </div>
 </div>
 
-
 [ronin-db]: https://github.com/ronin-rb/ronin-db#readme
 [ronin-db-synopsis]: https://github.com/ronin-rb/ronin-db#synopsis
 [ronin-db-activerecord]: https://github.com/ronin-rb/ronin-db-activerecord#readme

--- a/docs/guides/using-ronin-db/index.md
+++ b/docs/guides/using-ronin-db/index.md
@@ -158,14 +158,20 @@ there are pending migrations. You will have to run `ronin-db migrate`.
 
 <div class="level">
   <div class="level-left">
-    <a class="button" href="../using-the-ronin-cli/">
-      Using the Ronin CLI &raquo;
+    <a class="button" href="../using-ronin-repos/">
+      &laquo; Using Ronin Repos
     </a>
   </div>
 
   <div class="level-item">
-    <a class="button" href="../index.html#guides">
+    <a class="button" href="/docs/#guides">
       &#x2303; Guides
+    </a>
+  </div>
+
+  <div class="level-right">
+    <a class="button" href="../ruby-quick-ref/">
+      Ruby Quick Ref &raquo;
     </a>
   </div>
 </div>


### PR DESCRIPTION
Related to #48 

Repairing the Guides link for the "Using Ronin DB" page and repairing the previous and next link to the "Ronin Repo" and "Ruby Quick Ref" pages respectively.