### PR TITLE
Fixed the broken Guides link in Ruby Quick Ref guide

### DIFF
--- a/docs/guides/ruby-quick-ref/index.md
+++ b/docs/guides/ruby-quick-ref/index.md
@@ -616,9 +616,6 @@ end</pre>
 
 <div class="level">
   <div class="level-left">
-    <a class="button" href="../using-ronin-db/">
-      &laquo; Using Ronin DB
-    </a>
   </div>
 
   <div class="level-item">

--- a/docs/guides/ruby-quick-ref/index.md
+++ b/docs/guides/ruby-quick-ref/index.md
@@ -616,10 +616,13 @@ end</pre>
 
 <div class="level">
   <div class="level-left">
+    <a class="button" href="../using-ronin-db/">
+      &laquo; Using Ronin DB
+    </a>
   </div>
 
   <div class="level-item">
-    <a class="button" href="../index.html#guides">
+    <a class="button" href="/docs/#guides">
       &#x2303; Guides
     </a>
   </div>


### PR DESCRIPTION
Related to #48 

Repairing the Guides link for the "Ruby Quick Ref" page.