### PR TITLE
Fixed the broken Guides link in Writing Ronin Ruby Scripts guide

### DIFF
--- a/docs/guides/writing-ronin-ruby-scripts/index.md
+++ b/docs/guides/writing-ronin-ruby-scripts/index.md
@@ -126,7 +126,7 @@ and networking.
   </div>
 
   <div class="level-item">
-    <a class="button" href="../index.html#guides">
+    <a class="button" href="/docs/#guides">
       &#x2303; Guides
     </a>
   </div>


### PR DESCRIPTION
Repairing the Guides link for the "Writing Ronin Ruby Scripts" page.