### PR TITLE
Changed cursor on hover

### DIFF
--- a/stylesheets/default.css
+++ b/stylesheets/default.css
@@ -89,6 +89,7 @@ header a {
  */
 button#dark-mode-toggle {
 	background: none;
+	cursor: pointer;
 	border: none;
 }
 


### PR DESCRIPTION
The cursor now turns to a **pointer** when hovering on the dark mode icon in the home page header.

Reference:![2023-10-14 16_56_26-Ronin and 5 more pages - Personal - Microsoft​ Edge](https://github.com/ronin-rb/ronin-web/assets/133931559/991fc264-91f7-44cc-868d-2c384871a265)

