### PR TITLE
Direct link to index.md of specific folders

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,26 +5,26 @@ title: Guides
 
 # Guides
 
-* [Getting Started](getting-started/) -
+* [Getting Started](getting-started/index.md) -
   Explains how to install Ronin.
 
 ## CLI
 
-* [Using the Ronin CLI](using-the-ronin-cli/) -
+* [Using the Ronin CLI](using-the-ronin-cli/index.md) -
   Explains how to use Ronin's many commands and sub-commands.
-* [Using ronin-db](using-ronin-db/) -
+* [Using ronin-db](using-ronin-db/index.md) -
   Explains how to interact with Ronin's built-in database.
-* [Using ronin-repos](using-ronin-repos/) -
+* [Using ronin-repos](using-ronin-repos/index.md) -
   Explains how to install and manage 3rd-party git repositories that can contain
   exploits or payloads.
 
 ## Ruby
 
-* [Using the Ronin Ruby Shell](using-the-ronin-ruby-shell/) -
+* [Using the Ronin Ruby Shell](using-the-ronin-ruby-shell/index.md) -
   Explains how to use Ronin's interactive Ruby Shell.
-* [Ruby Quick Ref](ruby-quick-ref/) -
+* [Ruby Quick Ref](ruby-quick-ref/index.md) -
   Provides a quick reference of Ruby's syntax.
-* [Writing Ronin Ruby Scripts](writing-ronin-ruby-scripts/) -
+* [Writing Ronin Ruby Scripts](writing-ronin-ruby-scripts/index.md) -
   Explains how to write Ruby scripts using [ronin-support].
 
 [ronin-support]: https://github.com/ronin-rb/ronin-support#readme

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,41 +7,41 @@ title: Documentation
 
 ## Guides
 
-* [Getting Started](guides/getting-started/) -
+* [Getting Started](guides/getting-started/index.md) -
   Explains how to install Ronin.
 
 ### CLI
 
-* [Using the Ronin CLI](guides/using-the-ronin-cli/) -
+* [Using the Ronin CLI](guides/using-the-ronin-cli/index.md) -
   Explains how to use Ronin's many commands and sub-commands.
-* [Using ronin-db](guides/using-ronin-db/) -
+* [Using ronin-db](guides/using-ronin-db/index.md) -
   Explains how to interact with Ronin's built-in database.
-* [Using ronin-repos](guides/using-ronin-repos/) -
+* [Using ronin-repos](guides/using-ronin-repos/index.md) -
   Explains how to install and manage 3rd-party git repositories that can contain
   exploits or payloads.
 
 ### Ruby
 
-* [Using the Ronin Ruby Shell](guides/using-the-ronin-ruby-shell/) -
+* [Using the Ronin Ruby Shell](guides/using-the-ronin-ruby-shell/index.md) -
   Explains how to use Ronin's interactive Ruby Shell.
-* [Ruby Quick Ref](guides/ruby-quick-ref/) -
+* [Ruby Quick Ref](guides/ruby-quick-ref/index.md) -
   Provides a quick reference of Ruby's syntax.
-* [Writing Ronin Ruby Scripts](guides/writing-ronin-ruby-scripts/) -
+* [Writing Ronin Ruby Scripts](guides/writing-ronin-ruby-scripts/index.md) -
   Explains how to write Ruby scripts using [ronin-support].
 
 [ronin-support]: https://github.com/ronin-rb/ronin-support#readme
 
 ## Porting
 
-* [Porting Metasploit Exploits to Ronin Exploits](porting/metasploit-exploits-to-ronin-exploits/) -
+* [Porting Metasploit Exploits to Ronin Exploits](porting/metasploit-exploits-to-ronin-exploits/index.md) -
   A guide that explains how to convert Metasploit exploits into
   [Ronin exploits][ronin-exploits].
-* [Porting Metasploit Payloads to Ronin Payloads](porting/metasploit-payloads-to-ronin-payloads/) -
+* [Porting Metasploit Payloads to Ronin Payloads](porting/metasploit-payloads-to-ronin-payloads/index.md) -
   A guide that explains how to convert Metasploit payloads into
   [Ronin payloads][ronin-payloads].
-* [Porting Python to Ronin Quick Ref](porting/python-to-ronin-quick-ref/) -
+* [Porting Python to Ronin Quick Ref](porting/python-to-ronin-quick-ref/index.md) -
   Provides a quick references for converting Python code to Ronin.
-* [Porting Pwnlib to Ronin Quick Ref](porting/pwnlib-to-ronin-quick-ref/) -
+* [Porting Pwnlib to Ronin Quick Ref](porting/pwnlib-to-ronin-quick-ref/index.md) -
   Provides a quick references for converting Pwnlib code to Ronin.
 
 [ronin-exploits]: https://github.com/ronin-rb/ronin-exploits#readme

--- a/docs/porting/index.md
+++ b/docs/porting/index.md
@@ -5,15 +5,15 @@ title: Porting
 
 # Porting
 
-* [Porting Metasploit Exploits to Ronin Exploits](metasploit-exploits-to-ronin-exploits/) -
+* [Porting Metasploit Exploits to Ronin Exploits](metasploit-exploits-to-ronin-exploits/index.md) -
   A guide that explains how to convert Metasploit exploits into
   [Ronin exploits][ronin-exploits].
-* [Porting Metasploit Payloads to Ronin Payloads](metasploit-payloads-to-ronin-payloads/) -
+* [Porting Metasploit Payloads to Ronin Payloads](metasploit-payloads-to-ronin-payloads/index.md) -
   A guide that explains how to convert Metasploit payloads into
   [Ronin payloads][ronin-payloads].
-* [Porting Python to Ronin Quick Ref](python-to-ronin-quick-ref/) -
+* [Porting Python to Ronin Quick Ref](python-to-ronin-quick-ref/index.md) -
   Provides a quick references for converting Python code to Ronin.
-* [Porting Pwnlib to Ronin Quick Ref](pwnlib-to-ronin-quick-ref/) -
+* [Porting Pwnlib to Ronin Quick Ref](pwnlib-to-ronin-quick-ref/index.md) -
   Provides a quick references for converting Pwnlib code to Ronin.
 
 [ronin-exploits]: https://github.com/ronin-rb/ronin-exploits#readme


### PR DESCRIPTION
I have linked the links in index.md of docs folder directly to index.md of their specific folders as all the information required is in the index.md.

Earlier, the link redirected to the folder which the user required and to access information needed, he had to access index.md of that folder.
But I changed the links to directly redirect the user inside index.md file.

If any change is required, I will be more than happy to make the change.

Kindly accept this PR under hacktoberfest.